### PR TITLE
修改 slack 监听方式，不再需要服务器和公网 IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,14 +352,14 @@ Follow [官方文档](https://support.google.com/mail/answer/185833?hl=en) to cr
 
 ### 8.Slack
 
-**需要：** 服务器、 Slack 应用
+**❉不再需要服务器以及公网 IP**
 
-**Contributor:** [amao](https://github.com/amaoo)
+**Contributor:** [amaoo](https://github.com/amaoo)
 
 **依赖**
 
 ```bash
-pip3 install slack_bolt flask
+pip3 install slack_bolt
 ```
 
 **配置**
@@ -369,37 +369,35 @@ pip3 install slack_bolt flask
     "type": "slack",
     "slack": {
       "slack_bot_token": "xoxb-xxxx",
-      "slack_signing_secret": "xxxx"
+      "slack_app_token": "xapp-xxxx"
     }
   }
 ```
 
-需要 80 端口,可以在 **channel/slack/slack_channel.py:45** 修改相应端口
+**设置机器人令牌范围 - OAuth & Permission**
 
-将范围设置为机器人令牌范围 OAuth & Permission:
+将 Bot User OAuth Token 写入配置文件 slack_bot_token
 
 ```
 app_mentions:read
-channels:join
 chat:write
-im:history
-im:read
-im:writ
 ```
 
-在事件订阅中设置范围 - Subscribe to bot events
+
+**开启 Socket 模式 - Socket Mode**
+
+如未创建应用级令牌，会提示创建
+将创建的 token 写入配置文件 slack_app_token
+
+
+**事件订阅(Event Subscriptions) - Subscribe to bot events**
 
 ```
 app_mention
 ```
 
-订阅 URL，如果端口是 80 ，可不填
 
-```
-http:/你的固定公网ip或者域名:端口/slack/events
-```
-
-参考文档
+**参考文档**
 
 ```
 https://slack.dev/bolt-python/tutorial/getting-started

--- a/channel/slack/slack_channel.py
+++ b/channel/slack/slack_channel.py
@@ -1,23 +1,17 @@
-import json
 import re
-from flask import Flask, request, Response
 from slack_bolt import App
-from slack_bolt.adapter.flask import SlackRequestHandler
+from slack_bolt.adapter.socket_mode import SocketModeHandler
 from common import const
 from common.log import logger
 from channel.channel import Channel
 from config import channel_conf
 
-# 创建 Flask 实例
-flask_app = Flask(__name__)
-
 # 创建 Slack Bolt 实例
-app = App(token=channel_conf(const.SLACK).get('slack_bot_token'),
-          signing_secret=channel_conf(const.SLACK).get('slack_signing_secret'))
+app = App(token=channel_conf(const.SLACK).get('slack_bot_token'))
 
-# 创建 SlackRequestHandler 实例
-handler = SlackRequestHandler(app)
-
+# 创建 SocketModeHandler 实例
+handler = SocketModeHandler(app=app,
+                            app_token=channel_conf(const.SLACK).get('slack_app_token'))
 
 # 监听 Slack app_mention 事件
 @app.event("app_mention")
@@ -29,20 +23,9 @@ def handle_mention(event, say):
     reply_text = SlackChannel().handle(event)
     say(text=f"{reply_text}", thread_ts=ts)
 
-
-# 监听所有来自 Slack 的事件，并将它们转发到 Slack 应用处理
-@flask_app.route("/slack/events", methods=["POST"])
-def slack_events():
-    data = json.loads(request.data)
-    if data['type'] == 'url_verification':
-        return f"{data['challenge']}", 200
-    handler.handle(request)
-    return "ok", 200
-
-
 class SlackChannel(Channel):
     def startup(self):
-        flask_app.run(host='0.0.0.0', port=80)
+        handler.start()
 
     def handle(self, event):
         context = dict()

--- a/config-template.json
+++ b/config-template.json
@@ -40,7 +40,7 @@
 
     "slack": {
       "slack_bot_token": "xoxb-xxxx",
-      "slack_signing_secret": "xxxx"
+      "slack_app_token": "xapp-xxxx"
     },
 
     "http": {


### PR DESCRIPTION
采用 slack socket 模式，移除相关 web 代码
**不再需要服务器和公网 IP**