### PR TITLE
fix: log of null values

### DIFF
--- a/model/bing/new_bing_model.py
+++ b/model/bing/new_bing_model.py
@@ -55,7 +55,7 @@ class BingModel(Model):
                 answer = asyncio.run(task)
             except Exception as e:
                 bot.pop_last_conversation()
-                log.exception(answer)
+                log.exception(e)
                 return f"AI生成内容被微软内容过滤器拦截,已删除最后一次提问的记忆,请尝试使用其他文字描述问题,若AI依然无法正常回复,请使用{clear_memory_commands[0]}命令清除全部记忆"
             # 最新一条回复
             try:


### PR DESCRIPTION
这段代码的会在 answer 变量尚未定义或初始化时进入 except 块导致错误：
```python
            try:
                answer = asyncio.run(task)
            except Exception as e:
                bot.pop_last_conversation()
                log.exception(answer)
                return f"AI生成内容被微软内容过滤器拦截,已删除最后一次提问的记忆,请尝试使用其他文字描述问题,若AI依然无法正常回复,请使用{clear_memory_commands[0]}命令清除全部记忆"
```
这里我消除了它：
```python
          log.exception(e)
```